### PR TITLE
Add Docker support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,19 +21,19 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  # Run tests.
-  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
-  test:
+  # Build Docker image
+  build:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Run tests
+      - name: Build Docker image
         run: docker build . --file Dockerfile
 
+  # Publish built Docker image to the configured registry
   push:
-    needs: test
+    needs: build
     if: ${{ github.event_name != 'pull_request' }}
     permissions:
       contents: read

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,66 @@
+---
+name: Docker
+
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+  # Run tests for any PRs.
+  pull_request:
+    branches:
+      - master
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run tests
+        run: docker build . --file Dockerfile
+
+  push:
+    needs: test
+    if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      contents: read
+      packages: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Log into GitHub Container Registry
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:alpine as build
+WORKDIR /app
+COPY . .
+RUN go build
+
+FROM alpine:latest
+COPY --from=build /app/jaf /app/jaf
+WORKDIR /app
+CMD ["./jaf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,5 @@ RUN go build
 FROM alpine:latest
 COPY --from=build /app/jaf /app/jaf
 WORKDIR /app
+RUN mkdir -p /var/www/jaf
 CMD ["./jaf"]

--- a/README.md
+++ b/README.md
@@ -54,6 +54,24 @@ jaf -configFile example.conf
 ```
 Of course, you can also write a init system script to handle this for you.
 
+### Running from Docker
+Running it from the GitHub Container Registry
+```bash
+docker run \
+    -v /path/to/your/config.conf:/app/jaf.conf \
+    -v /path/to/where/you/want/your/files/to/be/stored:/FileDir/in/your/config \
+    ghcr.io/leon-richardt/jaf:latest
+```
+
+Building the Docker image and running it locally
+```bash
+docker build -t jaf .
+docker run \
+    -v /path/to/your/config.conf:/app/jaf.conf \
+    -v /path/to/where/you/want/your/files/to/be/stored:/FileDir/in/your/config \
+    jaf
+```
+
 ## Usage
 You can use jaf with any application that can send POST requests (e.g. ShareX/ShareNix or just `curl`).
 Make sure the file you want to upload is attached as a `multipart/form-data` field named `file`.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Running it from the GitHub Container Registry
 docker run \
     -p 4712:4711 \
     -v /path/to/your/config.conf:/app/jaf.conf \
-    -v /path/to/where/you/want/your/files/to/be/stored:/FileDir/in/your/config \
+    -v /path/to/local/filedir:/var/www/jaf \
     ghcr.io/leon-richardt/jaf:latest
 ```
 
@@ -70,7 +70,7 @@ docker build -t jaf .
 docker run \
     -p 4712:4711 \
     -v /path/to/your/config.conf:/app/jaf.conf \
-    -v /path/to/where/you/want/your/files/to/be/stored:/FileDir/in/your/config \
+    -v /path/to/local/filedir:/var/www/jaf \
     jaf
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Of course, you can also write a init system script to handle this for you.
 Running it from the GitHub Container Registry
 ```bash
 docker run \
+    -p 4712:4711 \
     -v /path/to/your/config.conf:/app/jaf.conf \
     -v /path/to/where/you/want/your/files/to/be/stored:/FileDir/in/your/config \
     ghcr.io/leon-richardt/jaf:latest
@@ -67,10 +68,14 @@ Building the Docker image and running it locally
 ```bash
 docker build -t jaf .
 docker run \
+    -p 4712:4711 \
     -v /path/to/your/config.conf:/app/jaf.conf \
     -v /path/to/where/you/want/your/files/to/be/stored:/FileDir/in/your/config \
     jaf
 ```
+
+Port 4711 is the default port for the server in `example.conf`, if you've changed this in your config you'll need to change this in the `docker run` invocations above too.  
+The above runs forwards the jaf port from 4711 in the container to 4712 on your local system.
 
 ## Usage
 You can use jaf with any application that can send POST requests (e.g. ShareX/ShareNix or just `curl`).


### PR DESCRIPTION
 - Added Docker support
 - Instructions for how to build & use it added to README.md
 - Add GitHub workflow to publishing the docker image to the GitHub Container Repository
   There's two jobs in this GitHub workflow: **test** and **push**. **test** runs on pushes to master, any time a version tag (e.g. `v1.2.3`) is pushed, and on pull requests targeting the master branch. **push** only runs on pushes to the master branch or when a version tag is pushed.

Question: Want me to add a GitHub workflow that runs the tests? Right now the only thing that would cause the workflow to fail would be if the project fails in the building stage