### PR TITLE
Update example config FileDir to `/var/www/jaf/`

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -1,5 +1,5 @@
 Port:       4711
 # a comment
 LinkPrefix: https://jaf.example.com/
-FileDir:    /var/www/jaf.example.com/
+FileDir:    /var/www/jaf/
 LinkLength: 5


### PR DESCRIPTION
As discussed in this PR: https://github.com/leon-richardt/jaf/pull/2

> That's precisely what I meant. I'm only still debating whether the /var/www/jaf.example.com/ path would serve as a good default – that seems a little weird to have in the actual setup. Maybe something like /var/www/jaf/ would be nicer
