### PR TITLE
fix(config_test): update test expectation for `FileDir`

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -24,6 +24,6 @@ func TestConfigFromFile(t *testing.T) {
 
 	assertEqualInt(config.Port, 4711, t)
 	assertEqualString(config.LinkPrefix, "https://jaf.example.com/", t)
-	assertEqualString(config.FileDir, "/var/www/jaf.example.com/", t)
+	assertEqualString(config.FileDir, "/var/www/jaf/", t)
 	assertEqualInt(config.LinkLength, 5, t)
 }


### PR DESCRIPTION
Another follow-up to #3 ...

> The value for FileDir was updated in PR #3 but we missed also updating
the test in config_test.go. This is a hint that we should maybe setup a
GitHub Action to run tests on PRs. :-)