### PR TITLE
ci: Add build and test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+---
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        go: [1.18, 1.19]
+
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+
+      - uses: actions/checkout@v3
+
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+
+      - name: Build
+        run: go build
+
+      - name: Test
+        run: go test -v ./...


### PR DESCRIPTION
Adds a simple workflow that builds & tests the project

As a sidenote, the build step is technically doubled now as we build it in the docker workflow too

If desired, the docker workflow can be expanded with a test step but I feel like keeping that workflow thin is worth the duplicate build