### PR TITLE
ref!: use generics to simply testing logic

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -4,15 +4,9 @@ import (
 	"testing"
 )
 
-func assertEqualInt(have int, want int, t *testing.T) {
+func assertEqual[S comparable](have S, want S, t *testing.T) {
 	if have != want {
-		t.Errorf("have: %d, want: %d\n", have, want)
-	}
-}
-
-func assertEqualString(have string, want string, t *testing.T) {
-	if have != want {
-		t.Errorf("have: %s, want: %s\n", have, want)
+		t.Error("have:", have, ", want:", want, "\n")
 	}
 }
 
@@ -22,8 +16,8 @@ func TestConfigFromFile(t *testing.T) {
 		panic(err)
 	}
 
-	assertEqualInt(config.Port, 4711, t)
-	assertEqualString(config.LinkPrefix, "https://jaf.example.com/", t)
-	assertEqualString(config.FileDir, "/var/www/jaf/", t)
-	assertEqualInt(config.LinkLength, 5, t)
+	assertEqual(config.Port, 4711, t)
+	assertEqual(config.LinkPrefix, "https://jaf.example.com/", t)
+	assertEqual(config.FileDir, "/var/www/jaf/", t)
+	assertEqual(config.LinkLength, 5, t)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/leon-richardt/jaf
 
-go 1.16
+go 1.19


### PR DESCRIPTION
Notably, this requires us to bump the Go version in order to use
generics. We now use Go 1.19.