### PR TITLE
ref: error out on unknown config keys

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/go-errors/errors"
 )
 
 const (
@@ -142,7 +144,7 @@ func ConfigFromFile(filePath string) (*Config, error) {
 
 			retval.ExifAbortOnError = parsed
 		default:
-			log.Printf("unexpected key: \"%s\", ignoring\n", key)
+			return nil, errors.Errorf("unexpected config key: \"%s\"", key)
 		}
 	}
 

--- a/jaf.go
+++ b/jaf.go
@@ -37,7 +37,7 @@ func main() {
 	// Read config
 	config, err := ConfigFromFile(params.configFile)
 	if err != nil {
-		log.Fatalf("could not read config file: %s\n", err.Error())
+		log.Fatalf("could not parse config file: %s\n", err.Error())
 	}
 
 	handler := uploadHandler{


### PR DESCRIPTION
Resolves #10.

This is an attempt at preventing misconfigurations introduced through typos.